### PR TITLE
Update sns filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - TBH
+### Removed
+- database filter from SNS filter policy.
+
 ## [2.0.0] - 2019-10-04
 ### Added
 - SQS permissions policy.

--- a/privileges-grantor/main.tf
+++ b/privileges-grantor/main.tf
@@ -48,55 +48,55 @@ resource "aws_iam_role_policy_attachment" "privilege_grantor_role_policy_attach"
   policy_arn = "${aws_iam_policy.privilege_grantor_lambda_vpc_access.arn}"
 }
 
-#resource "aws_sqs_queue" "privilege_grantor_sqs_queue" {
-#  name                       = "${local.instance_alias}-sqs-queue"
-#  visibility_timeout_seconds = "${var.lambda_timeout}"
-#}
-#
-#resource "aws_sqs_queue_policy" "privilege_grantor_sqs_queue_policy" {
-#  queue_url = "${aws_sqs_queue.privilege_grantor_sqs_queue.id}"
-#
-#  policy = <<POLICY
-#{
-#  "Version": "2012-10-17",
-#  "Id": "AllowSNSSendMessage",
-#  "Statement": [
-#    {
-#      "Sid": "Allow Apiary Metadata Events",
-#      "Effect": "Allow",
-#      "Principal": "*",
-#      "Action": "sqs:SendMessage",
-#      "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}",
-#      "Condition": {
-#        "ArnEquals": {
-#          "aws:SourceArn": "${var.metastore_events_sns_topic}"
-#        }
-#      }
-#    }
-#  ]
-#}
-#POLICY
-#}
+resource "aws_sqs_queue" "privilege_grantor_sqs_queue" {
+  name                       = "${local.instance_alias}-sqs-queue"
+  visibility_timeout_seconds = "${var.lambda_timeout}"
+}
 
-#resource "aws_iam_role_policy" "sqs_for_privilege_grantor" {
-#  name = "${local.instance_alias}-sqs-policy"
-#  role = "${aws_iam_role.iam_for_privilege_grantor.id}"
-#
-#  policy = <<EOF
-#{
-#    "Version": "2012-10-17",
-#    "Statement": {
-#        "Effect": "Allow",
-#        "Action": [
-#          "sqs:ReceiveMessage",
-#          "sqs:DeleteMessage",
-#          "sqs:GetQueueAttributes"
-#        ],
-#        "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
-#    }
-#}
-#EOF
-#}
+resource "aws_sqs_queue_policy" "privilege_grantor_sqs_queue_policy" {
+  queue_url = "${aws_sqs_queue.privilege_grantor_sqs_queue.id}"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Id": "AllowSNSSendMessage",
+  "Statement": [
+    {
+      "Sid": "Allow Apiary Metadata Events",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "sqs:SendMessage",
+      "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "${var.metastore_events_sns_topic}"
+        }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "sqs_for_privilege_grantor" {
+  name = "${local.instance_alias}-sqs-policy"
+  role = "${aws_iam_role.iam_for_privilege_grantor.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": {
+        "Effect": "Allow",
+        "Action": [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes"
+        ],
+        "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
+    }
+}
+EOF
+}
 
 data "template_file" "filter_policy" {
   template = <<JSON
@@ -142,9 +142,9 @@ resource "aws_lambda_function" "privilege_grantor_fn" {
   tags = "${var.tags}"
 }
 
-#resource "aws_lambda_event_source_mapping" "sqs_lambda_mapping" {
-#  batch_size       = 1
-#  event_source_arn = "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
-#  function_name    = "${aws_lambda_function.privilege_grantor_fn.arn}"
-#  enabled          = true
-#}
+resource "aws_lambda_event_source_mapping" "sqs_lambda_mapping" {
+  batch_size       = 1
+  event_source_arn = "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
+  function_name    = "${aws_lambda_function.privilege_grantor_fn.arn}"
+  enabled          = true
+}

--- a/privileges-grantor/main.tf
+++ b/privileges-grantor/main.tf
@@ -104,8 +104,7 @@ $${val}
 JSON
     vars {
         val = "${jsonencode(map(
-                    "eventType", "${compact(split(",",upper(join(",",var.metastore_events_filter))))}",
-                    "dbName", "${compact(split(",",lower(join(",",var.database_filter))))}"
+                    "eventType", "${compact(split(",",upper(join(",",var.metastore_events_filter))))}"
                 ))}"
       }
 }

--- a/privileges-grantor/main.tf
+++ b/privileges-grantor/main.tf
@@ -48,55 +48,55 @@ resource "aws_iam_role_policy_attachment" "privilege_grantor_role_policy_attach"
   policy_arn = "${aws_iam_policy.privilege_grantor_lambda_vpc_access.arn}"
 }
 
-resource "aws_sqs_queue" "privilege_grantor_sqs_queue" {
-  name                       = "${local.instance_alias}-sqs-queue"
-  visibility_timeout_seconds = "${var.lambda_timeout}"
-}
+#resource "aws_sqs_queue" "privilege_grantor_sqs_queue" {
+#  name                       = "${local.instance_alias}-sqs-queue"
+#  visibility_timeout_seconds = "${var.lambda_timeout}"
+#}
+#
+#resource "aws_sqs_queue_policy" "privilege_grantor_sqs_queue_policy" {
+#  queue_url = "${aws_sqs_queue.privilege_grantor_sqs_queue.id}"
+#
+#  policy = <<POLICY
+#{
+#  "Version": "2012-10-17",
+#  "Id": "AllowSNSSendMessage",
+#  "Statement": [
+#    {
+#      "Sid": "Allow Apiary Metadata Events",
+#      "Effect": "Allow",
+#      "Principal": "*",
+#      "Action": "sqs:SendMessage",
+#      "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}",
+#      "Condition": {
+#        "ArnEquals": {
+#          "aws:SourceArn": "${var.metastore_events_sns_topic}"
+#        }
+#      }
+#    }
+#  ]
+#}
+#POLICY
+#}
 
-resource "aws_sqs_queue_policy" "privilege_grantor_sqs_queue_policy" {
-  queue_url = "${aws_sqs_queue.privilege_grantor_sqs_queue.id}"
-
-  policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Id": "AllowSNSSendMessage",
-  "Statement": [
-    {
-      "Sid": "Allow Apiary Metadata Events",
-      "Effect": "Allow",
-      "Principal": "*",
-      "Action": "sqs:SendMessage",
-      "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}",
-      "Condition": {
-        "ArnEquals": {
-          "aws:SourceArn": "${var.metastore_events_sns_topic}"
-        }
-      }
-    }
-  ]
-}
-POLICY
-}
-
-resource "aws_iam_role_policy" "sqs_for_privilege_grantor" {
-  name = "${local.instance_alias}-sqs-policy"
-  role = "${aws_iam_role.iam_for_privilege_grantor.id}"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": {
-        "Effect": "Allow",
-        "Action": [
-          "sqs:ReceiveMessage",
-          "sqs:DeleteMessage",
-          "sqs:GetQueueAttributes"
-        ],
-        "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
-    }
-}
-EOF
-}
+#resource "aws_iam_role_policy" "sqs_for_privilege_grantor" {
+#  name = "${local.instance_alias}-sqs-policy"
+#  role = "${aws_iam_role.iam_for_privilege_grantor.id}"
+#
+#  policy = <<EOF
+#{
+#    "Version": "2012-10-17",
+#    "Statement": {
+#        "Effect": "Allow",
+#        "Action": [
+#          "sqs:ReceiveMessage",
+#          "sqs:DeleteMessage",
+#          "sqs:GetQueueAttributes"
+#        ],
+#        "Resource": "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
+#    }
+#}
+#EOF
+#}
 
 data "template_file" "filter_policy" {
   template = <<JSON
@@ -111,8 +111,8 @@ JSON
 
 resource "aws_sns_topic_subscription" "sqs_hive_metastore_sns_subscription" {
   topic_arn = "${var.metastore_events_sns_topic}"
-  protocol  = "sqs"
-  endpoint  = "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
+  protocol  = "lambda"
+  endpoint  = "${aws_lambda_function.privilege_grantor_fn.arn}"
 
   filter_policy = "${data.template_file.filter_policy.rendered}"
 }
@@ -142,9 +142,9 @@ resource "aws_lambda_function" "privilege_grantor_fn" {
   tags = "${var.tags}"
 }
 
-resource "aws_lambda_event_source_mapping" "sqs_lambda_mapping" {
-  batch_size       = 1
-  event_source_arn = "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
-  function_name    = "${aws_lambda_function.privilege_grantor_fn.arn}"
-  enabled          = true
-}
+#resource "aws_lambda_event_source_mapping" "sqs_lambda_mapping" {
+#  batch_size       = 1
+#  event_source_arn = "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
+#  function_name    = "${aws_lambda_function.privilege_grantor_fn.arn}"
+#  enabled          = true
+#}

--- a/privileges-grantor/main.tf
+++ b/privileges-grantor/main.tf
@@ -111,8 +111,8 @@ JSON
 
 resource "aws_sns_topic_subscription" "sqs_hive_metastore_sns_subscription" {
   topic_arn = "${var.metastore_events_sns_topic}"
-  protocol  = "lambda"
-  endpoint  = "${aws_lambda_function.privilege_grantor_fn.arn}"
+  protocol  = "sqs"
+  endpoint  = "${aws_sqs_queue.privilege_grantor_sqs_queue.arn}"
 
   filter_policy = "${data.template_file.filter_policy.rendered}"
 }

--- a/privileges-grantor/variables.tf
+++ b/privileges-grantor/variables.tf
@@ -41,14 +41,9 @@ variable "metastore_events_sns_topic" {
 }
 
 variable "metastore_events_filter" {
-  description = "List of metastore event types to be added to SNS filter. Supported format: `<<EOD \"CREATE_TABLE\",\"ALTER_TABLE\" EOD`"
+  description = "List of metastore event types to be added to SNS filter."
   type        = "list"
   default     = [ "CREATE_TABLE","ALTER_TABLE" ]
-}
-
-variable "database_filter" {
-  description = "List of database names to be added to SNS filter. Supported format: `<<EOD \"DB_NAME_1\",\"DB_NAME_2\" EOD`"
-  type        = "list"
 }
 
 # Tags


### PR DESCRIPTION
removed the database filter as the Apiary metastore event messages do not add the dbnames as message attribute in the sns messages. Thus we can't filter by them.